### PR TITLE
replaced the deprecated getRecentBlockhash with getLatestBlockhash

### DIFF
--- a/core/src/createTransfer.ts
+++ b/core/src/createTransfer.ts
@@ -1,5 +1,5 @@
 import { createTransferCheckedInstruction, getAccount, getAssociatedTokenAddress, getMint } from '@solana/spl-token';
-import type { Commitment, Connection, PublicKey } from '@solana/web3.js';
+import type { Commitment, Connection, GetLatestBlockhashConfig, PublicKey } from '@solana/web3.js';
 import { LAMPORTS_PER_SOL, SystemProgram, Transaction, TransactionInstruction } from '@solana/web3.js';
 import BigNumber from 'bignumber.js';
 import { MEMO_PROGRAM_ID, SOL_DECIMALS, TEN } from './constants.js';
@@ -34,7 +34,7 @@ export interface CreateTransferFields {
  * @param connection - A connection to the cluster.
  * @param sender - Account that will send the transfer.
  * @param fields - Fields of a Solana Pay transfer request URL.
- * @param options - Options for `getRecentBlockhash`.
+ * @param options - Options for `getLatestBlockhash`.
  *
  * @throws {CreateTransferError}
  */
@@ -42,7 +42,7 @@ export async function createTransfer(
     connection: Connection,
     sender: PublicKey,
     { recipient, amount, splToken, reference, memo }: CreateTransferFields,
-    { commitment }: { commitment?: Commitment } = {}
+    { commitment }: { commitment?: Commitment | GetLatestBlockhashConfig } = {}
 ): Promise<Transaction> {
     // Check that the sender and recipient accounts exist
     const senderInfo = await connection.getAccountInfo(sender);
@@ -70,7 +70,7 @@ export async function createTransfer(
     // Create the transaction
     const transaction = new Transaction();
     transaction.feePayer = sender;
-    transaction.recentBlockhash = (await connection.getRecentBlockhash(commitment)).blockhash;
+    transaction.recentBlockhash = (await connection.getLatestBlockhash(commitment)).blockhash;
 
     // If a memo is provided, add it to the transaction before adding the transfer instruction
     if (memo != null) {

--- a/core/src/fetchTransaction.ts
+++ b/core/src/fetchTransaction.ts
@@ -1,4 +1,4 @@
-import type { Commitment, Connection, PublicKey } from '@solana/web3.js';
+import type { Commitment, Connection, GetLatestBlockhashConfig, PublicKey } from '@solana/web3.js';
 import { Transaction } from '@solana/web3.js';
 import fetch from 'cross-fetch';
 import { toUint8Array } from 'js-base64';
@@ -17,7 +17,7 @@ export class FetchTransactionError extends Error {
  * @param connection - A connection to the cluster.
  * @param account - Account that may sign the transaction.
  * @param link - `link` in the [Solana Pay spec](https://github.com/solana-labs/solana-pay/blob/master/SPEC.md#link).
- * @param options - Options for `getRecentBlockhash`.
+ * @param options - Options for `getLatestBlockhash`.
  *
  * @throws {FetchTransactionError}
  */
@@ -25,7 +25,7 @@ export async function fetchTransaction(
     connection: Connection,
     account: PublicKey,
     link: string | URL,
-    { commitment }: { commitment?: Commitment } = {}
+    { commitment }: { commitment?: Commitment | GetLatestBlockhashConfig } = {}
 ): Promise<Transaction> {
     const response = await fetch(String(link), {
         method: 'POST',
@@ -60,7 +60,7 @@ export async function fetchTransaction(
             } else if (publicKey.equals(account)) {
                 // If the only signature expected is for `account`, ignore the recent blockhash in the transaction.
                 if (signatures.length === 1) {
-                    transaction.recentBlockhash = (await connection.getRecentBlockhash(commitment)).blockhash;
+                    transaction.recentBlockhash = (await connection.getLatestBlockhash(commitment)).blockhash;
                 }
             } else {
                 throw new FetchTransactionError('missing signature');
@@ -69,7 +69,7 @@ export async function fetchTransaction(
     } else {
         // Ignore the fee payer and recent blockhash in the transaction and initialize them.
         transaction.feePayer = account;
-        transaction.recentBlockhash = (await connection.getRecentBlockhash(commitment)).blockhash;
+        transaction.recentBlockhash = (await connection.getLatestBlockhash(commitment)).blockhash;
     }
 
     return transaction;


### PR DESCRIPTION
Fixes #242 

The `createTransfer` and `fetchTransaction` functions use `getRecentBlockhash` internally which has been deprecated and now it's throwing:
```
Error: failed to get recent blockhash:
SolanaJSONRPCError: failed to get recent blockhash: Method not found
```

The solution for this is to use the replacement function `getLatestBlockhash` instead. I have this already running in production and fixed my problem.

For anyone needing this urgently, change the version in your `package.json` to: `"@solana/pay": "https://gitpkg.vercel.app/0x2539/solana-pay/core?fix/latest-blockhash-build"`