### PR TITLE
Update repository organization from solana-labs to solana-foundation

### DIFF
--- a/core/package.json
+++ b/core/package.json
@@ -2,7 +2,7 @@
     "name": "@solana/pay",
     "version": "0.2.6",
     "author": "Solana Maintainers <maintainers@solana.foundation>",
-    "repository": "https://github.com/solana-labs/solana-pay",
+    "repository": "https://github.com/solana-foundation/solana-pay",
     "license": "Apache-2.0",
     "type": "module",
     "sideEffects": false,


### PR DESCRIPTION
## Update repository organization from solana-labs to solana-foundation

### Summary
Updates the repository field in `package.json` to reflect the correct organization ownership under the Solana Foundation.

### Changes
- Updated repository URL from `https://github.com/solana-labs/solana-pay` to `https://github.com/solana-foundation/solana-pay`

### Impact
- Ensures package registry and tooling correctly reference the canonical repository location
- Maintains consistency with the actual repository ownership structure
- No functional changes to the codebase

### Type of Change
- [x] Documentation/metadata update
- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
